### PR TITLE
BLEN-294: Assign MaterialX materials

### DIFF
--- a/materialx/ui.py
+++ b/materialx/ui.py
@@ -65,15 +65,20 @@ class MATERIALX_OP_export_file(bpy.types.Operator, ExportHelper):
         options={'HIDDEN'},
     )
     export_textures: bpy.props.BoolProperty(
-        name="Export textures",
+        name="Export Textures",
         description="Export bound textures to corresponded folder",
         default=True
     )
     texture_dir_name: bpy.props.StringProperty(
-        name="Folder name",
+        name="Folder Name",
         description="Texture folder name used for exporting files",
         default='textures',
         maxlen=1024,
+    )
+    export_deps: bpy.props.BoolProperty(
+        name="Export Dependencies",
+        description="Export MaterialX library dependencies",
+        default=True
     )
 
     def execute(self, context):
@@ -95,6 +100,8 @@ class MATERIALX_OP_export_file(bpy.types.Operator, ExportHelper):
         row = col.row()
         row.enabled = self.export_textures
         row.prop(self, 'texture_dir_name', text='')
+
+        self.layout.prop(self, 'export_deps')
 
 
 class MATERIALX_OP_export_console(bpy.types.Operator):

--- a/materialx/ui.py
+++ b/materialx/ui.py
@@ -81,7 +81,10 @@ class MATERIALX_OP_export_file(bpy.types.Operator, ExportHelper):
         if not doc:
             return {'CANCELLED'}
 
-        utils.export_to_file(doc, self.filepath, self.export_textures, self.texture_dir_name)
+        utils.export_to_file(doc, self.filepath,
+                             export_textures=self.export_textures,
+                             texture_dir_name=self.texture_dir_name,
+                             export_deps=False)
 
         return {'FINISHED'}
 

--- a/materialx/ui.py
+++ b/materialx/ui.py
@@ -89,8 +89,10 @@ class MATERIALX_OP_export_file(bpy.types.Operator, ExportHelper):
         utils.export_to_file(doc, self.filepath,
                              export_textures=self.export_textures,
                              texture_dir_name=self.texture_dir_name,
-                             export_deps=False)
+                             export_deps=self.export_deps,
+                             copy_deps=self.export_deps)
 
+        log.info(f"Succesfully exported material '{context.material.name}' into {self.filepath}")
         return {'FINISHED'}
 
     def draw(self, context):

--- a/materialx/ui.py
+++ b/materialx/ui.py
@@ -10,7 +10,6 @@ import bpy
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 
 from . import utils
-from .utils import import_materialx_from_file, export
 from .preferences import addon_preferences
 
 from .utils import logging
@@ -39,7 +38,7 @@ class MATERIALX_OP_import_file(bpy.types.Operator, ImportHelper):
         search_path.append(str(utils.MX_LIBS_DIR))
         try:
             mx.readFromXmlFile(doc, str(mtlx_file))
-            import_materialx_from_file(mx_node_tree, doc, mtlx_file)
+            utils.import_materialx_from_file(mx_node_tree, doc, mtlx_file)
 
         except Exception as e:
             log.error(traceback.format_exc(), mtlx_file)
@@ -53,7 +52,6 @@ class MATERIALX_OP_export_file(bpy.types.Operator, ExportHelper):
     bl_label = "Export to File"
     bl_description = "Export material as MaterialX node tree to .mtlx file"
 
-    # region properties
     filename_ext = ".mtlx"
 
     filepath: bpy.props.StringProperty(
@@ -66,20 +64,10 @@ class MATERIALX_OP_export_file(bpy.types.Operator, ExportHelper):
         default="*.mtlx",
         options={'HIDDEN'},
     )
-    is_export_deps: bpy.props.BoolProperty(
-        name="Include dependencies",
-        description="Export used MaterialX dependencies",
-        default=False
-    )
-    is_export_textures: bpy.props.BoolProperty(
+    export_textures: bpy.props.BoolProperty(
         name="Export textures",
         description="Export bound textures to corresponded folder",
         default=True
-    )
-    is_clean_texture_folder: bpy.props.BoolProperty(
-        name="Сlean texture folder",
-        description="Сlean texture folder before export",
-        default=False
     )
     texture_dir_name: bpy.props.StringProperty(
         name="Folder name",
@@ -87,29 +75,22 @@ class MATERIALX_OP_export_file(bpy.types.Operator, ExportHelper):
         default='textures',
         maxlen=1024,
     )
-    # endregion
 
     def execute(self, context):
-        doc = export(context.material, None)
+        doc = utils.export(context.material, None)
         if not doc:
             return {'CANCELLED'}
 
-        utils.export_mx_to_file(doc, self.filepath,
-                                mx_node_tree=None,
-                                # is_export_deps=self.is_export_deps,
-                                is_export_textures=self.is_export_textures,
-                                texture_dir_name=self.texture_dir_name)
+        utils.export_to_file(doc, self.filepath, self.export_textures, self.texture_dir_name)
 
         return {'FINISHED'}
 
     def draw(self, context):
-        # self.layout.prop(self, 'is_export_deps')
-
         col = self.layout.column(align=False)
-        col.prop(self, 'is_export_textures')
+        col.prop(self, 'export_textures')
 
         row = col.row()
-        row.enabled = self.is_export_textures
+        row.enabled = self.export_textures
         row.prop(self, 'texture_dir_name', text='')
 
 
@@ -119,7 +100,7 @@ class MATERIALX_OP_export_console(bpy.types.Operator):
     bl_description = "Export material as MaterialX node tree to console"
 
     def execute(self, context):
-        doc = export(context.material, context.object)
+        doc = utils.export(context.material, context.object)
         if not doc:
             return {'CANCELLED'}
 

--- a/materialx/utils.py
+++ b/materialx/utils.py
@@ -246,43 +246,16 @@ def get_socket_color(mx_type):
     return (0.63, 0.63, 0.63, 1.0)
 
 
-def export_mx_to_file(doc, filepath, *, mx_node_tree=None, is_export_deps=False,
-                      is_export_textures=False, texture_dir_name='textures',
-                      is_clean_texture_folder=True, is_clean_deps_folders=True):
+def export_to_file(doc, filepath, export_textures=False, texture_dir_name='textures'):
     root_dir = Path(filepath).parent
 
     if not os.path.isdir(root_dir):
         Path(root_dir).mkdir(parents=True, exist_ok=True)
 
-    if is_export_deps and mx_node_tree:
-        mx_libs_dir = root_dir / MX_LIBS_FOLDER
-        if os.path.isdir(mx_libs_dir) and is_clean_deps_folders:
-            shutil.rmtree(mx_libs_dir)
-
-        # we need to export every deps only once
-        unique_paths = set(node._file_path for node in mx_node_tree.nodes)
-
-        for mtlx_path in unique_paths:
-            # defining paths
-            source_path = MX_LIBS_DIR.parent / mtlx_path
-            full_dest_path = root_dir / mtlx_path
-            rel_dest_path = full_dest_path.relative_to(root_dir / MX_LIBS_FOLDER)
-            dest_path = root_dir / rel_dest_path
-
-            Path(dest_path.parent).mkdir(parents=True, exist_ok=True)
-            shutil.copy(source_path, dest_path)
-
-            mx.prependXInclude(doc, str(rel_dest_path))
-
-    if is_export_textures:
+    if export_textures:
         texture_dir = root_dir / texture_dir_name
-        if os.path.isdir(texture_dir) and is_clean_texture_folder:
-            shutil.rmtree(texture_dir)
-
         image_paths = set()
-
         i = 0
-
         input_files = (v for v in doc.traverseTree() if isinstance(v, mx.Input) and v.getType() == 'filename')
         for mx_input in input_files:
             if not os.path.isdir(texture_dir):

--- a/materialx/utils.py
+++ b/materialx/utils.py
@@ -25,10 +25,6 @@ MX_ADDON_LIBS_DIR = ADDON_ROOT_DIR / MX_LIBS_FOLDER
 NODE_CLASSES_FOLDER = "materialx_nodes"
 NODE_CLASSES_DIR = ADDON_DATA_DIR / NODE_CLASSES_FOLDER
 
-MATLIB_FOLDER = "matlib"
-MATLIB_DIR = ADDON_DATA_DIR / MATLIB_FOLDER
-MATLIB_URL = "https://api.matlib.gpuopen.com/api"
-
 TEMP_FOLDER = "bl-materialx"
 
 NODE_LAYER_SEPARATION_WIDTH = 280
@@ -246,7 +242,7 @@ def get_socket_color(mx_type):
     return (0.63, 0.63, 0.63, 1.0)
 
 
-def export_to_file(doc, filepath, export_textures=False, texture_dir_name='textures'):
+def export_to_file(doc, filepath, *, export_textures=False, texture_dir_name='textures', export_deps=True):
     root_dir = Path(filepath).parent
 
     if not os.path.isdir(root_dir):
@@ -288,7 +284,16 @@ def export_to_file(doc, filepath, export_textures=False, texture_dir_name='textu
             rel_dest_path = dest_path.relative_to(root_dir)
             mx_input.setValue(str(rel_dest_path), mx_input.getType())
 
-    mx.writeToXmlFile(doc, filepath)
+    if export_deps:
+        from .nodes import get_mx_node_cls
+
+        mx_nodes = [it for it in doc.traverseTree() if isinstance(it, mx.Node)]
+        node_classes = {get_mx_node_cls(mx_node)[0] for mx_node in mx_nodes}
+        print(node_classes)
+        for cls in node_classes:
+            mx.prependXInclude(doc, cls._file_path)
+
+    mx.writeToXmlFile(doc, str(filepath))
     log(f"Export MaterialX to {filepath}: completed successfully")
 
 

--- a/materialx/utils.py
+++ b/materialx/utils.py
@@ -289,7 +289,6 @@ def export_to_file(doc, filepath, *, export_textures=False, texture_dir_name='te
 
         mx_nodes = [it for it in doc.traverseTree() if isinstance(it, mx.Node)]
         node_classes = {get_mx_node_cls(mx_node)[0] for mx_node in mx_nodes}
-        print(node_classes)
         for cls in node_classes:
             mx.prependXInclude(doc, cls._file_path)
 


### PR DESCRIPTION
Fixed code in `utils.export_to_file()` (renamed from `export_mx_to_file()`)
Made code cleanups/improvements.